### PR TITLE
Change logic to show description also for active filters whose facet …

### DIFF
--- a/Resources/frontend/js/jquery.prefix-filter-value.js
+++ b/Resources/frontend/js/jquery.prefix-filter-value.js
@@ -24,6 +24,7 @@
             this.opts.filtersIdToBePrefix = filterPrefixList;
             me.$filterForm = $(me.opts.filterFormSelector);
             me.$filterComponents = me.$filterForm.find(me.opts.filterComponentSelector);
+
             me.assignFiltersName();
             me.onUpdateActiveFilterElement();
             me.onCreateActiveFilterElement();
@@ -34,13 +35,29 @@
             $.each(me.$filterComponents, function (index, filterSelector) {
                 $.each(me.opts.filtersIdToBePrefix, function (index, filterId) {
                     var filterData = $(filterSelector).data('field-name');
-                    if (filterData === filterId) {
-                        var labelText = $(filterSelector).find('label[for='+  filterId  +']').text();
-                        me.opts.filtersName[filterId] = $.trim(labelText);
+                    if (filterData !== filterId) {
+                        return;
                     }
+                    me.assign(filterSelector, filterId);
                 })
 
             })
+        },
+
+        assign: function (filterSelector, filterId) {
+            var me = this,
+                labelText = $(filterSelector).find('label[for='+  filterId  +']').text(),
+                filterIndex = filterId + '_' + labelText;
+
+            me.opts.filtersName[filterIndex] = {text: $.trim(labelText), names: []};
+
+            $(filterSelector).find('input').each(function () {
+                var filterName = $(this).attr('name');
+
+                if (null != filterName) {
+                    me.opts.filtersName[filterIndex]['names'].push(filterName);
+                }
+            });
         },
 
         onUpdateActiveFilterElement: function () {
@@ -58,10 +75,11 @@
         },
 
         setFilterPrefix: function (data, param, label) {
-            $.each(this.opts.filtersName, function (filterId, filterName) {
-                if (param.indexOf(filterId) !== -1) {
-                    data.activeFilterElements[param].html(data.getLabelIcon() + filterName + ': ' + label);
+            $.each(this.opts.filtersName, function (index, filterData) {
+                if ($.inArray(param, filterData['names']) === -1) {
+                    return;
                 }
+                data.activeFilterElements[param].html(data.getLabelIcon() + filterData['text'] + ': ' + label);
             })
         },
     });

--- a/plugin.xml
+++ b/plugin.xml
@@ -3,7 +3,7 @@
         xsi:noNamespaceSchemaLocation="../../../engine/Shopware/Components/Plugin/schema/plugin.xsd">
     <label lang="de">nlxFilterDescription</label>
     <label lang="en">nlxFilterDescription</label>
-    <version>2.0.0</version>
+    <version>2.1.0</version>
     <copyright>(c) by netlogix GmbH &amp; Co. KG</copyright>
     <license>Proprietary</license>
     <link>https://websolutions.netlogix.de/</link>
@@ -18,5 +18,9 @@
     <changelog version="2.0.0">
         <changes lang="de">Plugin zu Netlogix Struktur migriert</changes>
         <changes lang="en">Plugin migrated to Netlogix structure</changes>
+    </changelog>
+    <changelog version="2.1.0">
+        <changes lang="de">Zeige die Beschreibung auch bei aktiven Filtern an, deren Facet auf der Seite mehrmals definiert ist z.B. Eigenschaften (Größen, Farbe)</changes>
+        <changes lang="en">Show the description also for active filters whose facet is defined several times on the page e.g. properties (size, color)</changes>
     </changelog>
 </plugin>


### PR DESCRIPTION
…is defined several times on the page.

At the moment it can happen if one facet is defined several times on the page, the description of that facet, will be overwritten with the last defined facet description.
Example: The facet property is defined two times as color and size. The description of the active filters will be always size because it is the last defined one. This happen because we use the facet name "property" as id to match the description with the correct facet.